### PR TITLE
Add interpolation implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca387cdc0a1f9c7a7c26556d584aa2d07fc529843082e4861003cde4ab914ed"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1536,33 @@ dependencies = [
  "termcolor",
  "thiserror 2.0.11",
  "unicode-xid",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2299,6 +2345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2590,7 @@ version = "4.0.3"
 dependencies = [
  "apodize",
  "cpal",
+ "nalgebra",
  "realfft",
  "thiserror 2.0.11",
  "tracing",
@@ -2607,6 +2669,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -2972,6 +3047,12 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -3372,6 +3453,16 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/shady-audio/Cargo.toml
+++ b/shady-audio/Cargo.toml
@@ -16,3 +16,4 @@ tracing.workspace = true
 thiserror.workspace = true
 
 apodize = "1"
+nalgebra = "0.33"

--- a/shady-audio/src/config.rs
+++ b/shady-audio/src/config.rs
@@ -4,16 +4,9 @@
 use std::{
     num::{NonZero, NonZeroU32, NonZeroUsize},
     ops::Range,
-    time::Duration,
 };
 
 use crate::Error;
-
-/// Default value for [ShadyAudioConfig.refresh_time].
-/// Set to `100` millis.
-///
-/// [ShadyAudioConfig.refresh_time]: struct.ShadyAudioConfig.html#structfield.refresh_time
-pub const DEFAULT_REFRESH_TIME: Duration = Duration::from_millis(100);
 
 /// Configure the behaviour of [ShadyAudio] by setting the appropriate values in this struct
 /// and give it to [ShadyAudio].
@@ -29,16 +22,6 @@ pub const DEFAULT_REFRESH_TIME: Duration = Duration::from_millis(100);
 /// [ShadyAudio]: crate::ShadyAudio
 #[derive(Debug, Clone, Hash)]
 pub struct ShadyAudioConfig {
-    /// The duration how long shady should wait, until it should fetch
-    /// from the audio source again.
-    ///
-    /// The rule is basically: The higher the duration, the slower your
-    /// music visualizer becomes.
-    ///
-    /// # Default
-    /// See [DEFAULT_REFRESH_TIME
-    pub refresh_time: Duration,
-
     /// Set the amount bars which should be used.
     pub amount_bars: NonZeroUsize,
 
@@ -80,7 +63,6 @@ impl ShadyAudioConfig {
 impl Default for ShadyAudioConfig {
     fn default() -> Self {
         Self {
-            refresh_time: DEFAULT_REFRESH_TIME,
             amount_bars: NonZeroUsize::new(30).unwrap(),
             freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(10_000).unwrap(),
         }

--- a/shady-audio/src/config.rs
+++ b/shady-audio/src/config.rs
@@ -82,7 +82,7 @@ impl Default for ShadyAudioConfig {
         Self {
             refresh_time: DEFAULT_REFRESH_TIME,
             amount_bars: NonZeroUsize::new(32).unwrap(),
-            freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(10_000).unwrap(),
+            freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(20_000).unwrap(),
         }
     }
 }

--- a/shady-audio/src/config.rs
+++ b/shady-audio/src/config.rs
@@ -6,7 +6,7 @@ use std::{
     ops::Range,
 };
 
-use crate::Error;
+use crate::{interpolation::InterpolationVariant, Error};
 
 /// Configure the behaviour of [ShadyAudio] by setting the appropriate values in this struct
 /// and give it to [ShadyAudio].
@@ -39,6 +39,9 @@ pub struct ShadyAudioConfig {
     /// };
     /// ```
     pub freq_range: Range<NonZeroU32>,
+
+    /// Decide which interpolation should be used for the bars.
+    pub interpolation: InterpolationVariant,
 }
 
 impl ShadyAudioConfig {
@@ -65,6 +68,7 @@ impl Default for ShadyAudioConfig {
         Self {
             amount_bars: NonZeroUsize::new(30).unwrap(),
             freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(10_000).unwrap(),
+            interpolation: InterpolationVariant::CubicSpline,
         }
     }
 }

--- a/shady-audio/src/config.rs
+++ b/shady-audio/src/config.rs
@@ -81,8 +81,8 @@ impl Default for ShadyAudioConfig {
     fn default() -> Self {
         Self {
             refresh_time: DEFAULT_REFRESH_TIME,
-            amount_bars: NonZeroUsize::new(32).unwrap(),
-            freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(20_000).unwrap(),
+            amount_bars: NonZeroUsize::new(30).unwrap(),
+            freq_range: NonZeroU32::new(50).unwrap()..NonZero::new(10_000).unwrap(),
         }
     }
 }

--- a/shady-audio/src/equalizer.rs
+++ b/shady-audio/src/equalizer.rs
@@ -128,7 +128,6 @@ impl Equalizer {
         for (supporting_point, info) in self
             .interpolator
             .supporting_points_mut()
-            .into_iter()
             .zip(self.supporting_point_infos.iter_mut())
         {
             let x = supporting_point.x;

--- a/shady-audio/src/equalizer.rs
+++ b/shady-audio/src/equalizer.rs
@@ -1,7 +1,8 @@
 use core::f32;
-use std::{num::NonZeroUsize, ops::Range};
+use std::{fmt::Write, num::NonZeroUsize, ops::Range};
 
 use cpal::SampleRate;
+use nalgebra::{DMatrix, DVector};
 use realfft::num_complex::Complex32;
 use tracing::{debug, instrument};
 
@@ -10,9 +11,10 @@ use crate::{Hz, MAX_HUMAN_FREQUENCY, MIN_HUMAN_FREQUENCY};
 const DEFAULT_INIT_SENSITIVITY: f32 = 1.;
 
 #[derive(Debug, Clone)]
-struct AnchorSection {
+struct SupportingPoint {
     // the range within the fft output which should be used
     fft_range: Range<usize>,
+
     // which bar value should get the value
     bar_value_idx: usize,
 }
@@ -21,7 +23,12 @@ struct AnchorSection {
 struct InterpolationSection {
     // the starting index within `bar_values` which should be calculated
     start: usize,
+
     amount: NonZeroUsize,
+
+    // the index within the `supporting_points` vector of the ending supporting point
+    // within the section
+    ending_supporting_point_idx: usize,
 }
 
 #[derive(Debug)]
@@ -29,7 +36,7 @@ pub struct Equalizer {
     bar_values: Box<[f32]>,
     started_falling: Box<[bool]>,
 
-    anchor_sections: Box<[AnchorSection]>,
+    supporting_points: Box<[SupportingPoint]>,
     interpolation_sections: Box<[InterpolationSection]>,
 
     sensitivity: f32,
@@ -51,7 +58,7 @@ impl Equalizer {
         let bar_values = vec![0.; amount_bars].into_boxed_slice();
         let started_falling = vec![false; amount_bars].into_boxed_slice();
 
-        let (anchor_sections, interpolation_sections) = {
+        let (supporting_points, isections) = {
             // == preparations
             let weights = (1..(amount_bars + 1))
                 .map(|index| exp_fun(index as f32 / amount_bars as f32))
@@ -73,8 +80,8 @@ impl Equalizer {
             debug!("Available bins: {}", amount_bins);
 
             // == fill sections
-            let mut anchor_sections = Vec::new();
-            let mut interpolation_sections = Vec::new();
+            let mut supporting_points = Vec::new();
+            let mut isections = Vec::new();
 
             let mut interpol_section: Option<InterpolationSection> = None;
             let mut prev_fft_range = 0..0;
@@ -94,16 +101,18 @@ impl Equalizer {
                         interpol_section = Some(InterpolationSection {
                             start: bar_value_idx,
                             amount: NonZeroUsize::new(1).unwrap(),
+                            ending_supporting_point_idx: 0,
                         });
                     }
                 } else {
                     // new anchor
-                    if let Some(inter) = interpol_section.clone() {
-                        interpolation_sections.push(inter);
+                    if let Some(mut inter) = interpol_section.clone() {
+                        inter.ending_supporting_point_idx = supporting_points.len();
+                        isections.push(inter);
                         interpol_section = None;
                     }
 
-                    anchor_sections.push(AnchorSection {
+                    supporting_points.push(SupportingPoint {
                         fft_range: new_fft_range.clone(),
                         bar_value_idx,
                     });
@@ -115,18 +124,18 @@ impl Equalizer {
             assert!(interpol_section.is_none());
 
             (
-                anchor_sections.into_boxed_slice(),
-                interpolation_sections.into_boxed_slice(),
+                supporting_points.into_boxed_slice(),
+                isections.into_boxed_slice(),
             )
         };
 
-        debug!("Anchor sections: {:#?}", &anchor_sections);
-        debug!("Interpolation sections: {:#?}", &interpolation_sections);
+        debug!("Anchor sections: {:#?}", &supporting_points);
+        debug!("Interpolation sections: {:#?}", &isections);
 
         Self {
             bar_values,
-            anchor_sections,
-            interpolation_sections,
+            supporting_points,
+            interpolation_sections: isections,
             started_falling,
             sensitivity: init_sensitivity.unwrap_or(DEFAULT_INIT_SENSITIVITY),
             overshoot: false,
@@ -155,7 +164,7 @@ impl Equalizer {
     }
 
     fn process_anchors(&mut self, fft_out: &[Complex32]) {
-        for section in self.anchor_sections.iter() {
+        for section in self.supporting_points.iter() {
             let i = section.bar_value_idx;
 
             let prev_magnitude = self.bar_values[i];
@@ -207,6 +216,169 @@ impl Equalizer {
     }
 
     fn process_interpolate(&mut self) {
+        self.process_cubic_spline_interpolation();
+        // self.process_linear_interpolation();
+    }
+
+    fn process_cubic_spline_interpolation(&mut self) {
+        let section_widths = {
+            let mut section_width = Vec::with_capacity(self.supporting_points.len() - 1);
+
+            let mut prev_width = self.supporting_points[0].bar_value_idx;
+            for anchor in self.supporting_points[1..].iter() {
+                let width = anchor.bar_value_idx - prev_width;
+                prev_width = anchor.bar_value_idx;
+
+                assert!(width > 0);
+
+                section_width.push(width);
+            }
+
+            section_width
+        };
+        let amount_sections = section_widths.len();
+        debug_assert!(amount_sections + 1 == self.supporting_points.len());
+        debug!("Section widths:\n{:?}", section_widths);
+
+        let matrix = {
+            let mut matrix = DMatrix::zeros(amount_sections, amount_sections);
+
+            // add first row
+            {
+                let mut first_row = matrix.row_mut(0);
+                first_row[0] = 2. * section_widths[0] as f32;
+                first_row[1] = section_widths[0] as f32;
+            }
+
+            // add rows in between
+            {
+                let mut offset = 0;
+                for row_idx in 1..(amount_sections - 1) {
+                    let mut row = matrix.row_mut(row_idx);
+
+                    row[offset] = section_widths[offset] as f32;
+                    row[offset + 1] =
+                        2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
+                    row[offset + 2] = section_widths[offset + 1] as f32;
+
+                    offset += 1;
+                }
+            }
+
+            // add last row
+            {
+                let mut last_row = matrix.row_mut(amount_sections - 1);
+
+                last_row[amount_sections - 2] = section_widths[amount_sections - 1] as f32;
+                last_row[amount_sections - 1] = 2. * section_widths[amount_sections - 1] as f32;
+            }
+
+            // just for debugging purposes
+            {
+                let mut dbg_matrix_msg = String::new();
+                for row_idx in 0..amount_sections {
+                    let row = matrix.row(row_idx);
+                    write!(&mut dbg_matrix_msg, "[").unwrap();
+                    for &value in row.columns_range(..amount_sections - 1) {
+                        write!(&mut dbg_matrix_msg, "{value}, ").unwrap();
+                    }
+                    write!(&mut dbg_matrix_msg, "{}]\n", row[amount_sections - 1]).unwrap();
+                }
+                debug!("Matrix:\n{}", dbg_matrix_msg)
+            }
+
+            matrix * (1. / 6.)
+        };
+        debug_assert_eq!(matrix.row(0).len(), amount_sections);
+        debug_assert_eq!(matrix.column(0).len(), amount_sections);
+
+        let gradients = {
+            let mut gradients = Vec::with_capacity(amount_sections);
+
+            for (i, right) in self.supporting_points[1..].iter().enumerate() {
+                let left = &self.supporting_points[i];
+                let left_x = left.bar_value_idx;
+                let left_y = self.bar_values[left_x];
+
+                let right_x = right.bar_value_idx;
+                let right_y = self.bar_values[right_x];
+
+                let gradient = (left_y - right_y) / (left_x as f32 - right_x as f32);
+
+                gradients.push(gradient);
+            }
+
+            gradients
+        };
+        debug_assert_eq!(gradients.len(), amount_sections);
+        debug!("Gradients: {:?}", gradients);
+
+        let gradient_diffs = {
+            let mut gradient_diffs = Vec::with_capacity(amount_sections);
+
+            // first diff
+            gradient_diffs.push(gradients[0]);
+
+            // d1 to d(N - 1)
+            for (i, next_gradient) in gradients[1..gradients.len() - 1]
+                .iter()
+                .cloned()
+                .enumerate()
+            {
+                let prev_gradient = gradients[i];
+
+                gradient_diffs.push(next_gradient - prev_gradient);
+            }
+
+            // last diff
+            gradient_diffs.push(gradients[gradients.len() - 1]);
+
+            gradient_diffs
+        };
+        debug_assert_eq!(gradient_diffs.len(), amount_sections);
+
+        let l = matrix
+            .cholesky()
+            .expect("Hold up! Looks like I failed my numeric exam... ;------;");
+        let gammas = l.solve(&DVector::from_row_slice(gradient_diffs.as_slice()));
+        debug_assert_eq!(gammas.len(), amount_sections);
+
+        // now let's do the actual calculation
+        for section in self.interpolation_sections.iter() {
+            let n = section.ending_supporting_point_idx;
+
+            let prev_supporting_point = &self.supporting_points[n - 1];
+            let prev_x = prev_supporting_point.bar_value_idx;
+            let prev_y = self.bar_values[prev_x];
+            let prev_gamma = gammas[n - 1];
+
+            let next_supporting_point = &self.supporting_points[n];
+            let next_x = next_supporting_point.bar_value_idx;
+            let next_gamma = gammas[n];
+
+            let gradient = gradients[n - 1];
+            let section_width = section_widths[n - 1];
+
+            let amount = usize::from(section.amount);
+            for idx in 0..amount {
+                let idx = usize::from(idx);
+
+                let x = (idx + 1 + prev_x) as f32;
+
+                let interpolated_value = prev_y
+                    + (x - prev_x as f32) * gradient
+                    + ((x - prev_x as f32) * (x - next_x as f32)) / (6. * section_width as f32)
+                        * ((prev_gamma + 2. * next_gamma) * (x - prev_x as f32)
+                            - (2. * prev_gamma + next_gamma) * (x - next_x as f32));
+
+                self.bar_values[section.start + idx] = interpolated_value;
+                debug!("Interpolated values: {}", interpolated_value);
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn process_linear_interpolation(&mut self) {
         for section in self.interpolation_sections.iter() {
             let amount = usize::from(section.amount);
             let start_anchor_value = self.bar_values[section.start - 1];
@@ -216,7 +388,7 @@ impl Equalizer {
             for (i, bar_value_idx) in range.enumerate() {
                 let t = (i + 1) as f32 / (amount + 1) as f32;
                 self.bar_values[bar_value_idx] =
-                    t * start_anchor_value + (1. - t) * end_anchor_value;
+                    t * end_anchor_value + (1. - t) * start_anchor_value;
             }
         }
     }

--- a/shady-audio/src/equalizer.rs
+++ b/shady-audio/src/equalizer.rs
@@ -1,47 +1,42 @@
 use core::f32;
-use std::{fmt::Write, num::NonZeroUsize, ops::Range};
+use std::ops::Range;
 
 use cpal::SampleRate;
-use nalgebra::{DMatrix, DVector};
 use realfft::num_complex::Complex32;
 use tracing::{debug, instrument};
 
-use crate::{Hz, MAX_HUMAN_FREQUENCY, MIN_HUMAN_FREQUENCY};
+use crate::{
+    interpolation::{
+        Interpolater, InterpolationInstantiator, LinearInterpolation, SupportingPoint,
+    },
+    Hz, MAX_HUMAN_FREQUENCY, MIN_HUMAN_FREQUENCY,
+};
 
 const DEFAULT_INIT_SENSITIVITY: f32 = 1.;
 
-#[derive(Debug, Clone)]
-struct SupportingPoint {
-    // the range within the fft output which should be used
-    fft_range: Range<usize>,
-
-    // which bar value should get the value
-    bar_value_idx: usize,
-}
-
-#[derive(Debug, Clone)]
-struct InterpolationSection {
-    // the starting index within `bar_values` which should be calculated
-    start: usize,
-
-    amount: NonZeroUsize,
-
-    // the index within the `supporting_points` vector of the ending supporting point
-    // within the section
-    ending_supporting_point_idx: usize,
-}
-
+/// Additional information about the supporting points
 #[derive(Debug)]
+struct SupportingPointInfo {
+    /// which fft bins of the fft output should be used for the given bar
+    fft_bin_range: Range<usize>,
+    /// if the bar just started falling
+    started_falling: bool,
+}
+
+impl SupportingPointInfo {
+    pub fn new(fft_bin_range: Range<usize>) -> Self {
+        Self {
+            fft_bin_range,
+            started_falling: false,
+        }
+    }
+}
+
 pub struct Equalizer {
-    bar_values: Box<[f32]>,
-    started_falling: Box<[bool]>,
-
-    supporting_points: Box<[SupportingPoint]>,
-    interpolation_sections: Box<[InterpolationSection]>,
-
     sensitivity: f32,
-    is_silent: bool,
-    overshoot: bool,
+
+    supporting_point_infos: Box<[SupportingPointInfo]>,
+    interpolator: Box<dyn Interpolater>,
 }
 
 impl Equalizer {
@@ -55,13 +50,13 @@ impl Equalizer {
     ) -> Self {
         assert!(sample_rate.0 > 0);
 
-        let bar_values = vec![0.; amount_bars].into_boxed_slice();
-        let started_falling = vec![false; amount_bars].into_boxed_slice();
+        let (supporting_points, supporting_point_infos) = {
+            let mut supporting_points = Vec::new();
+            let mut supporting_point_infos = Vec::with_capacity(amount_bars);
 
-        let (supporting_points, isections) = {
             // == preparations
-            let weights = (1..(amount_bars + 1))
-                .map(|index| exp_fun(index as f32 / amount_bars as f32))
+            let weights = (0..amount_bars)
+                .map(|index| exp_fun((index + 1) as f32 / (amount_bars + 1) as f32))
                 .collect::<Vec<f32>>();
             debug!("Weights: {:?}", weights);
 
@@ -79,319 +74,268 @@ impl Equalizer {
             };
             debug!("Available bins: {}", amount_bins);
 
-            // == fill sections
-            let mut supporting_points = Vec::new();
-            let mut isections = Vec::new();
-
-            let mut interpol_section: Option<InterpolationSection> = None;
+            // == calculate sections
             let mut prev_fft_range = 0..0;
-
-            for (bar_value_idx, weight) in weights.iter().enumerate() {
+            for (bar_idx, weight) in weights.iter().enumerate() {
                 let end =
                     ((weight / MAX_HUMAN_FREQUENCY as f32) * amount_bins as f32).ceil() as usize;
 
                 let new_fft_range = prev_fft_range.end..end;
-                let is_interpolation_section =
-                    new_fft_range == prev_fft_range || new_fft_range.is_empty();
-                if is_interpolation_section {
-                    // interpolate
-                    if let Some(inter) = interpol_section.as_mut() {
-                        inter.amount = inter.amount.saturating_add(1);
-                    } else {
-                        interpol_section = Some(InterpolationSection {
-                            start: bar_value_idx,
-                            amount: NonZeroUsize::new(1).unwrap(),
-                            ending_supporting_point_idx: 0,
-                        });
-                    }
-                } else {
-                    // new anchor
-                    if let Some(mut inter) = interpol_section.clone() {
-                        inter.ending_supporting_point_idx = supporting_points.len();
-                        isections.push(inter);
-                        interpol_section = None;
-                    }
+                let is_supporting_point =
+                    new_fft_range != prev_fft_range && !new_fft_range.is_empty();
+                if is_supporting_point {
+                    supporting_points.push(SupportingPoint { x: bar_idx, y: 0. });
 
-                    supporting_points.push(SupportingPoint {
-                        fft_range: new_fft_range.clone(),
-                        bar_value_idx,
-                    });
+                    supporting_point_infos.push(SupportingPointInfo::new(new_fft_range.clone()));
                 }
 
                 prev_fft_range = new_fft_range;
             }
 
-            assert!(interpol_section.is_none());
-
-            (
-                supporting_points.into_boxed_slice(),
-                isections.into_boxed_slice(),
-            )
+            (supporting_points, supporting_point_infos.into_boxed_slice())
         };
 
-        debug!("Anchor sections: {:#?}", &supporting_points);
-        debug!("Interpolation sections: {:#?}", &isections);
+        let interpolator = LinearInterpolation::boxed(supporting_points);
 
         Self {
-            bar_values,
-            supporting_points,
-            interpolation_sections: isections,
-            started_falling,
+            supporting_point_infos,
             sensitivity: init_sensitivity.unwrap_or(DEFAULT_INIT_SENSITIVITY),
-            overshoot: false,
-            is_silent: true,
+            interpolator,
         }
     }
 
     pub fn process(&mut self, fft_out: &[Complex32]) -> &[f32] {
-        self.overshoot = false;
-        self.is_silent = true;
-
-        self.process_anchors(fft_out);
-        self.process_interpolate();
-
-        if self.overshoot {
+        let (overshoot, is_silent) = self.update_supporting_points(fft_out);
+        if overshoot {
             self.sensitivity *= 0.98;
-        } else if !self.is_silent {
+        } else if !is_silent {
             self.sensitivity *= 1.002;
         }
 
-        &self.bar_values
+        self.interpolator.interpolate()
     }
 
     pub fn sensitivity(&self) -> f32 {
         self.sensitivity
     }
 
-    fn process_anchors(&mut self, fft_out: &[Complex32]) {
-        for section in self.supporting_points.iter() {
-            let i = section.bar_value_idx;
+    fn update_supporting_points(&mut self, fft_out: &[Complex32]) -> (bool, bool) {
+        let mut overshoot = false;
+        let mut is_silent = true;
 
-            let prev_magnitude = self.bar_values[i];
+        let amount_bars = self.interpolator.total_amount_entries();
+
+        for (supporting_point, info) in self
+            .interpolator
+            .supporting_points_mut()
+            .into_iter()
+            .zip(self.supporting_point_infos.iter_mut())
+        {
+            let x = supporting_point.x;
+            let prev_magnitude = supporting_point.y;
             let next_magnitude = {
-                let raw_bar_val = fft_out[section.fft_range.clone()]
+                let raw_bar_val = fft_out[info.fft_bin_range.clone()]
                     .iter()
                     .map(|out| {
                         let mag = out.norm();
                         if mag > 0. {
-                            self.is_silent = false;
+                            is_silent = false;
                         }
-
                         mag
                     })
                     .max_by(|a, b| a.total_cmp(b))
                     .unwrap();
 
-                self.sensitivity
-                    * raw_bar_val
-                    * 10f32
-                        .powf((section.bar_value_idx as f32 / self.bar_values.len() as f32) - 1.1)
+                self.sensitivity * raw_bar_val * 10f32.powf((x as f32 / amount_bars as f32) - 1.1)
             };
 
             debug_assert!(!prev_magnitude.is_nan());
             debug_assert!(!next_magnitude.is_nan());
 
             let rel_change = next_magnitude / prev_magnitude;
-            if self.is_silent {
-                self.bar_values[i] *= 0.75;
-                self.started_falling[i] = false;
+            if is_silent {
+                supporting_point.y *= 0.75;
+                info.started_falling = false;
             } else {
-                let was_falling_before = self.started_falling[i];
+                let was_falling_before = info.started_falling;
                 let is_falling = next_magnitude < prev_magnitude;
 
                 if is_falling && !was_falling_before {
-                    self.started_falling[i] = true;
-                    self.bar_values[i] += (next_magnitude - prev_magnitude) * 0.1;
+                    info.started_falling = true;
+                    supporting_point.y += (next_magnitude - prev_magnitude) * 0.1;
                 } else {
-                    self.started_falling[i] = false;
-                    self.bar_values[i] +=
+                    info.started_falling = false;
+                    supporting_point.y +=
                         (next_magnitude - prev_magnitude) * rel_change.clamp(0.05, 0.2);
                 }
             }
 
-            if self.bar_values[i] > 1. {
-                self.overshoot = true;
+            if supporting_point.y > 1. {
+                overshoot = true;
             }
         }
+
+        (overshoot, is_silent)
     }
 
-    fn process_interpolate(&mut self) {
-        self.process_cubic_spline_interpolation();
-        // self.process_linear_interpolation();
-    }
+    // fn process_cubic_spline_interpolation(&mut self) {
+    //     let section_widths = {
+    //         let mut section_width = Vec::with_capacity(self.supporting_points.len() - 1);
 
-    fn process_cubic_spline_interpolation(&mut self) {
-        let section_widths = {
-            let mut section_width = Vec::with_capacity(self.supporting_points.len() - 1);
+    //         let mut prev_width = self.supporting_points[0].x;
+    //         for anchor in self.supporting_points[1..].iter() {
+    //             let width = anchor.x - prev_width;
+    //             prev_width = anchor.x;
 
-            let mut prev_width = self.supporting_points[0].bar_value_idx;
-            for anchor in self.supporting_points[1..].iter() {
-                let width = anchor.bar_value_idx - prev_width;
-                prev_width = anchor.bar_value_idx;
+    //             assert!(width > 0);
 
-                assert!(width > 0);
+    //             section_width.push(width);
+    //         }
 
-                section_width.push(width);
-            }
+    //         section_width
+    //     };
+    //     let amount_sections = section_widths.len();
+    //     debug_assert!(amount_sections + 1 == self.supporting_points.len());
+    //     debug!("Section widths:\n{:?}", section_widths);
 
-            section_width
-        };
-        let amount_sections = section_widths.len();
-        debug_assert!(amount_sections + 1 == self.supporting_points.len());
-        debug!("Section widths:\n{:?}", section_widths);
+    //     let matrix = {
+    //         let mut matrix = DMatrix::zeros(amount_sections, amount_sections);
 
-        let matrix = {
-            let mut matrix = DMatrix::zeros(amount_sections, amount_sections);
+    //         // add first row
+    //         {
+    //             let mut first_row = matrix.row_mut(0);
+    //             first_row[0] = 2. * section_widths[0] as f32;
+    //             first_row[1] = section_widths[0] as f32;
+    //         }
 
-            // add first row
-            {
-                let mut first_row = matrix.row_mut(0);
-                first_row[0] = 2. * section_widths[0] as f32;
-                first_row[1] = section_widths[0] as f32;
-            }
+    //         // add rows in between
+    //         {
+    //             let mut offset = 0;
+    //             for row_idx in 1..(amount_sections - 1) {
+    //                 let mut row = matrix.row_mut(row_idx);
 
-            // add rows in between
-            {
-                let mut offset = 0;
-                for row_idx in 1..(amount_sections - 1) {
-                    let mut row = matrix.row_mut(row_idx);
+    //                 row[offset] = section_widths[offset] as f32;
+    //                 row[offset + 1] =
+    //                     2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
+    //                 row[offset + 2] = section_widths[offset + 1] as f32;
 
-                    row[offset] = section_widths[offset] as f32;
-                    row[offset + 1] =
-                        2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
-                    row[offset + 2] = section_widths[offset + 1] as f32;
+    //                 offset += 1;
+    //             }
+    //         }
 
-                    offset += 1;
-                }
-            }
+    //         // add last row
+    //         {
+    //             let mut last_row = matrix.row_mut(amount_sections - 1);
 
-            // add last row
-            {
-                let mut last_row = matrix.row_mut(amount_sections - 1);
+    //             last_row[amount_sections - 2] = section_widths[amount_sections - 1] as f32;
+    //             last_row[amount_sections - 1] = 2. * section_widths[amount_sections - 1] as f32;
+    //         }
 
-                last_row[amount_sections - 2] = section_widths[amount_sections - 1] as f32;
-                last_row[amount_sections - 1] = 2. * section_widths[amount_sections - 1] as f32;
-            }
+    //         // just for debugging purposes
+    //         {
+    //             let mut dbg_matrix_msg = String::new();
+    //             for row_idx in 0..amount_sections {
+    //                 let row = matrix.row(row_idx);
+    //                 write!(&mut dbg_matrix_msg, "[").unwrap();
+    //                 for &value in row.columns_range(..amount_sections - 1) {
+    //                     write!(&mut dbg_matrix_msg, "{value}, ").unwrap();
+    //                 }
+    //                 write!(&mut dbg_matrix_msg, "{}]\n", row[amount_sections - 1]).unwrap();
+    //             }
+    //             debug!("Matrix:\n{}", dbg_matrix_msg)
+    //         }
 
-            // just for debugging purposes
-            {
-                let mut dbg_matrix_msg = String::new();
-                for row_idx in 0..amount_sections {
-                    let row = matrix.row(row_idx);
-                    write!(&mut dbg_matrix_msg, "[").unwrap();
-                    for &value in row.columns_range(..amount_sections - 1) {
-                        write!(&mut dbg_matrix_msg, "{value}, ").unwrap();
-                    }
-                    write!(&mut dbg_matrix_msg, "{}]\n", row[amount_sections - 1]).unwrap();
-                }
-                debug!("Matrix:\n{}", dbg_matrix_msg)
-            }
+    //         matrix * (1. / 6.)
+    //     };
+    //     debug_assert_eq!(matrix.row(0).len(), amount_sections);
+    //     debug_assert_eq!(matrix.column(0).len(), amount_sections);
 
-            matrix * (1. / 6.)
-        };
-        debug_assert_eq!(matrix.row(0).len(), amount_sections);
-        debug_assert_eq!(matrix.column(0).len(), amount_sections);
+    //     let gradients = {
+    //         let mut gradients = Vec::with_capacity(amount_sections);
 
-        let gradients = {
-            let mut gradients = Vec::with_capacity(amount_sections);
+    //         for (i, right) in self.supporting_points[1..].iter().enumerate() {
+    //             let left = &self.supporting_points[i];
+    //             let left_x = left.x;
+    //             let left_y = self.bar_values[left_x];
 
-            for (i, right) in self.supporting_points[1..].iter().enumerate() {
-                let left = &self.supporting_points[i];
-                let left_x = left.bar_value_idx;
-                let left_y = self.bar_values[left_x];
+    //             let right_x = right.x;
+    //             let right_y = self.bar_values[right_x];
 
-                let right_x = right.bar_value_idx;
-                let right_y = self.bar_values[right_x];
+    //             let gradient = (left_y - right_y) / (left_x as f32 - right_x as f32);
 
-                let gradient = (left_y - right_y) / (left_x as f32 - right_x as f32);
+    //             gradients.push(gradient);
+    //         }
 
-                gradients.push(gradient);
-            }
+    //         gradients
+    //     };
+    //     debug_assert_eq!(gradients.len(), amount_sections);
+    //     debug!("Gradients: {:?}", gradients);
 
-            gradients
-        };
-        debug_assert_eq!(gradients.len(), amount_sections);
-        debug!("Gradients: {:?}", gradients);
+    //     let gradient_diffs = {
+    //         let mut gradient_diffs = Vec::with_capacity(amount_sections);
 
-        let gradient_diffs = {
-            let mut gradient_diffs = Vec::with_capacity(amount_sections);
+    //         // first diff
+    //         gradient_diffs.push(gradients[0]);
 
-            // first diff
-            gradient_diffs.push(gradients[0]);
+    //         // d1 to d(N - 1)
+    //         for (i, next_gradient) in gradients[1..gradients.len() - 1]
+    //             .iter()
+    //             .cloned()
+    //             .enumerate()
+    //         {
+    //             let prev_gradient = gradients[i];
 
-            // d1 to d(N - 1)
-            for (i, next_gradient) in gradients[1..gradients.len() - 1]
-                .iter()
-                .cloned()
-                .enumerate()
-            {
-                let prev_gradient = gradients[i];
+    //             gradient_diffs.push(next_gradient - prev_gradient);
+    //         }
 
-                gradient_diffs.push(next_gradient - prev_gradient);
-            }
+    //         // last diff
+    //         gradient_diffs.push(gradients[gradients.len() - 1]);
 
-            // last diff
-            gradient_diffs.push(gradients[gradients.len() - 1]);
+    //         gradient_diffs
+    //     };
+    //     debug_assert_eq!(gradient_diffs.len(), amount_sections);
 
-            gradient_diffs
-        };
-        debug_assert_eq!(gradient_diffs.len(), amount_sections);
+    //     let l = matrix
+    //         .cholesky()
+    //         .expect("Hold up! Looks like I failed my numeric exam... ;------;");
+    //     let gammas = l.solve(&DVector::from_row_slice(gradient_diffs.as_slice()));
+    //     debug_assert_eq!(gammas.len(), amount_sections);
 
-        let l = matrix
-            .cholesky()
-            .expect("Hold up! Looks like I failed my numeric exam... ;------;");
-        let gammas = l.solve(&DVector::from_row_slice(gradient_diffs.as_slice()));
-        debug_assert_eq!(gammas.len(), amount_sections);
+    //     // now let's do the actual calculation
+    //     for section in self.interpolation_sections.iter() {
+    //         let n = section.ending_supporting_point_idx;
 
-        // now let's do the actual calculation
-        for section in self.interpolation_sections.iter() {
-            let n = section.ending_supporting_point_idx;
+    //         let prev_supporting_point = &self.supporting_points[n - 1];
+    //         let prev_x = prev_supporting_point.x;
+    //         let prev_y = self.bar_values[prev_x];
+    //         let prev_gamma = gammas[n - 1];
 
-            let prev_supporting_point = &self.supporting_points[n - 1];
-            let prev_x = prev_supporting_point.bar_value_idx;
-            let prev_y = self.bar_values[prev_x];
-            let prev_gamma = gammas[n - 1];
+    //         let next_supporting_point = &self.supporting_points[n];
+    //         let next_x = next_supporting_point.x;
+    //         let next_gamma = gammas[n];
 
-            let next_supporting_point = &self.supporting_points[n];
-            let next_x = next_supporting_point.bar_value_idx;
-            let next_gamma = gammas[n];
+    //         let gradient = gradients[n - 1];
+    //         let section_width = section_widths[n - 1];
 
-            let gradient = gradients[n - 1];
-            let section_width = section_widths[n - 1];
+    //         let amount = usize::from(section.amount);
+    //         for idx in 0..amount {
+    //             let idx = usize::from(idx);
 
-            let amount = usize::from(section.amount);
-            for idx in 0..amount {
-                let idx = usize::from(idx);
+    //             let x = (idx + 1 + prev_x) as f32;
 
-                let x = (idx + 1 + prev_x) as f32;
+    //             let interpolated_value = prev_y
+    //                 + (x - prev_x as f32) * gradient
+    //                 + ((x - prev_x as f32) * (x - next_x as f32)) / (6. * section_width as f32)
+    //                     * ((prev_gamma + 2. * next_gamma) * (x - prev_x as f32)
+    //                         - (2. * prev_gamma + next_gamma) * (x - next_x as f32));
 
-                let interpolated_value = prev_y
-                    + (x - prev_x as f32) * gradient
-                    + ((x - prev_x as f32) * (x - next_x as f32)) / (6. * section_width as f32)
-                        * ((prev_gamma + 2. * next_gamma) * (x - prev_x as f32)
-                            - (2. * prev_gamma + next_gamma) * (x - next_x as f32));
+    //             self.bar_values[section.start + idx] = interpolated_value;
+    //             debug!("Interpolated values: {}", interpolated_value);
+    //         }
+    //     }
+    // }
 
-                self.bar_values[section.start + idx] = interpolated_value;
-                debug!("Interpolated values: {}", interpolated_value);
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    fn process_linear_interpolation(&mut self) {
-        for section in self.interpolation_sections.iter() {
-            let amount = usize::from(section.amount);
-            let start_anchor_value = self.bar_values[section.start - 1];
-            let end_anchor_value = self.bar_values[section.start + amount];
-
-            let range = section.start..(section.start + amount);
-            for (i, bar_value_idx) in range.enumerate() {
-                let t = (i + 1) as f32 / (amount + 1) as f32;
-                self.bar_values[bar_value_idx] =
-                    t * end_anchor_value + (1. - t) * start_anchor_value;
-            }
-        }
-    }
+    // }
 }
 
 fn exp_fun(x: f32) -> f32 {

--- a/shady-audio/src/equalizer.rs
+++ b/shady-audio/src/equalizer.rs
@@ -7,7 +7,7 @@ use tracing::{debug, instrument};
 
 use crate::{
     interpolation::{
-        Interpolater, InterpolationInstantiator, LinearInterpolation, SupportingPoint,
+        CubicSplineInterpolation, Interpolater, InterpolationInstantiator, SupportingPoint,
     },
     Hz, MAX_HUMAN_FREQUENCY, MIN_HUMAN_FREQUENCY,
 };
@@ -95,7 +95,7 @@ impl Equalizer {
             (supporting_points, supporting_point_infos.into_boxed_slice())
         };
 
-        let interpolator = LinearInterpolation::boxed(supporting_points);
+        let interpolator = CubicSplineInterpolation::boxed(supporting_points);
 
         Self {
             supporting_point_infos,

--- a/shady-audio/src/interpolation/context.rs
+++ b/shady-audio/src/interpolation/context.rs
@@ -83,7 +83,7 @@ impl std::fmt::Debug for InterpolationCtx {
                 (None, None) => break,
             };
 
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
 
         Ok(())

--- a/shady-audio/src/interpolation/context.rs
+++ b/shady-audio/src/interpolation/context.rs
@@ -1,0 +1,223 @@
+use tracing::debug;
+
+use super::{InterpolationSection, SupportingPoint};
+
+#[derive(Clone)]
+pub struct InterpolationCtx {
+    pub supporting_points: Box<[SupportingPoint]>,
+    pub sections: Box<[InterpolationSection]>,
+}
+
+/// Constructing stuff
+impl InterpolationCtx {
+    pub fn new(supporting_points: impl IntoIterator<Item = super::SupportingPoint>) -> Self {
+        let supporting_points = supporting_points
+            .into_iter()
+            .collect::<Vec<SupportingPoint>>()
+            .into_boxed_slice();
+
+        let sections = {
+            let mut sections = Vec::new();
+
+            if supporting_points.len() > 1 {
+                for (i, supporting_point) in supporting_points[1..].iter().enumerate() {
+                    let prev_supporting_point = supporting_points.get(i).unwrap();
+
+                    let gap_size = supporting_point.x - prev_supporting_point.x - 1;
+                    let there_is_a_gap = gap_size > 0;
+                    if there_is_a_gap {
+                        sections.push(InterpolationSection {
+                            left_supporting_point_idx: i,
+                            amount: gap_size,
+                        });
+                    }
+                }
+            }
+
+            sections.into_boxed_slice()
+        };
+
+        let ctx = Self {
+            supporting_points,
+            sections,
+        };
+
+        debug!("{:?}", ctx);
+
+        ctx
+    }
+
+    pub fn total_amount_entries(&self) -> usize {
+        if let Some(last) = self.supporting_points.last() {
+            last.x + 1
+        } else {
+            0
+        }
+    }
+}
+
+impl std::fmt::Debug for InterpolationCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut sp_iter = self.supporting_points.iter().peekable();
+        let mut s_iter = self.sections.iter().peekable();
+
+        loop {
+            match (sp_iter.peek(), s_iter.peek()) {
+                (Some(sp), Some(s)) => {
+                    if sp.x <= s.left_supporting_point_idx {
+                        write!(f, "{:?}", sp)?;
+                        sp_iter.next();
+                    } else {
+                        write!(f, "{:?}", s)?;
+                        s_iter.next();
+                    }
+                }
+                (Some(sp), None) => {
+                    write!(f, "{:?}", sp)?;
+                    sp_iter.next();
+                }
+                (None, Some(s)) => {
+                    write!(f, "{:?}", s)?;
+                    s_iter.next();
+                }
+                (None, None) => break,
+            };
+
+            write!(f, "\n")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_points_no_sections() {
+        let ctx = InterpolationCtx::new([]);
+
+        assert!(ctx.supporting_points.is_empty());
+        assert!(ctx.sections.is_empty());
+    }
+
+    #[test]
+    fn one_point_no_sections() {
+        let supporting_points = [SupportingPoint { x: 0, y: 0.0 }];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert!(ctx.sections.is_empty());
+    }
+
+    #[test]
+    fn two_points_no_sections() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 1, y: 1.0 },
+        ];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert!(ctx.sections.is_empty());
+    }
+
+    #[test]
+    fn two_points_one_section() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 5, y: 1.0 },
+        ];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert_eq!(
+            ctx.sections.as_ref(),
+            &[InterpolationSection {
+                left_supporting_point_idx: 0,
+                amount: 4
+            }]
+        );
+    }
+
+    #[test]
+    fn three_points_one_section_at_the_beginning() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 2, y: 0.0 },
+            SupportingPoint { x: 3, y: 0.0 },
+        ];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert_eq!(
+            ctx.sections.as_ref(),
+            &[InterpolationSection {
+                left_supporting_point_idx: 0,
+                amount: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn three_points_one_section_in_the_end() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 1, y: 0.0 },
+            SupportingPoint { x: 3, y: 0.0 },
+        ];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert_eq!(
+            ctx.sections.as_ref(),
+            &[InterpolationSection {
+                left_supporting_point_idx: 1,
+                amount: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn three_points_two_sections() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 2, y: 0.0 },
+            SupportingPoint { x: 4, y: 0.0 },
+        ];
+
+        let ctx = InterpolationCtx::new(supporting_points.clone());
+
+        assert_eq!(ctx.supporting_points.as_ref(), &supporting_points);
+        assert_eq!(
+            ctx.sections.as_ref(),
+            &[
+                InterpolationSection {
+                    left_supporting_point_idx: 0,
+                    amount: 1
+                },
+                InterpolationSection {
+                    left_supporting_point_idx: 1,
+                    amount: 1
+                }
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_supporting_points_ordering() {
+        let supporting_points = [
+            SupportingPoint { x: 1, y: 0.0 },
+            SupportingPoint { x: 0, y: 0.0 },
+        ];
+
+        InterpolationCtx::new(supporting_points);
+    }
+}

--- a/shady-audio/src/interpolation/cubic_spline.rs
+++ b/shady-audio/src/interpolation/cubic_spline.rs
@@ -1,41 +1,33 @@
-use std::fmt::Write;
-
 use nalgebra::{Cholesky, DMatrix, DVector, Dyn};
-use tracing::debug;
 
-use super::{Interpolater, InterpolationCtx};
+use super::{context::InterpolationCtx, Interpolater, InterpolationInstantiator};
 
 type Width = usize;
 
 #[derive(Debug, Clone)]
 pub struct CubicSplineInterpolation {
+    values: Box<[f32]>,
+    ctx: InterpolationCtx,
+
     section_widths: Box<[Width]>,
 
     matrix: Cholesky<f32, Dyn>,
     gradients: Box<[f32]>,
     gradient_diffs: Box<[f32]>,
-
-    gammas: DVector<f32>,
 }
 
-impl CubicSplineInterpolation {
-    pub fn boxed(ctx: &InterpolationCtx) -> Box<Self> {
-        Box::new(Self::new(ctx))
-    }
-
-    pub fn new(ctx: &InterpolationCtx) -> Self {
-        let supporting_points = ctx.supporting_points();
+impl InterpolationInstantiator for CubicSplineInterpolation {
+    fn new(supporting_points: impl IntoIterator<Item = super::SupportingPoint>) -> Self {
+        let ctx = InterpolationCtx::new(supporting_points);
+        let values = vec![0f32; ctx.total_amount_entries()].into_boxed_slice();
 
         let section_widths = {
-            let mut section_width = Vec::with_capacity(supporting_points.len() - 1);
+            let mut section_width = Vec::with_capacity(ctx.supporting_points.len() - 1);
 
-            let mut prev_width = supporting_points[0].x;
-            for anchor in supporting_points[1..].iter() {
-                let width = anchor.x - prev_width;
-                prev_width = anchor.x;
+            for (i, right) in ctx.supporting_points[1..].iter().enumerate() {
+                let left = &ctx.supporting_points[i];
 
-                assert!(width > 0);
-
+                let width = right.x - left.x;
                 section_width.push(width);
             }
 
@@ -43,90 +35,47 @@ impl CubicSplineInterpolation {
         };
         let amount_sections = section_widths.len();
 
-        let matrix = {
-            let mut matrix = DMatrix::zeros(amount_sections, amount_sections);
-
-            // add first row
-            {
-                let mut first_row = matrix.row_mut(0);
-                first_row[0] = 2. * section_widths[0] as f32;
-                first_row[1] = section_widths[0] as f32;
-            }
-
-            // add rows in between
-            {
-                let mut offset = 0;
-                for row_idx in 1..(amount_sections - 1) {
-                    let mut row = matrix.row_mut(row_idx);
-
-                    row[offset] = section_widths[offset] as f32;
-                    row[offset + 1] =
-                        2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
-                    row[offset + 2] = section_widths[offset + 1] as f32;
-
-                    offset += 1;
-                }
-            }
-
-            // add last row
-            {
-                let mut last_row = matrix.row_mut(amount_sections - 1);
-
-                last_row[amount_sections - 2] = section_widths[amount_sections - 1] as f32;
-                last_row[amount_sections - 1] = 2. * section_widths[amount_sections - 1] as f32;
-            }
-
-            // just for debugging purposes
-            {
-                let mut dbg_matrix_msg = String::new();
-                for row_idx in 0..amount_sections {
-                    let row = matrix.row(row_idx);
-                    write!(&mut dbg_matrix_msg, "[").unwrap();
-                    for &value in row.columns_range(..amount_sections - 1) {
-                        write!(&mut dbg_matrix_msg, "{value}, ").unwrap();
-                    }
-                    write!(&mut dbg_matrix_msg, "{}]\n", row[amount_sections - 1]).unwrap();
-                }
-                debug!("Matrix:\n{}", dbg_matrix_msg)
-            }
-
-            debug_assert_eq!(matrix.row(0).len(), amount_sections);
-            debug_assert_eq!(matrix.column(0).len(), amount_sections);
-
-            ((1. / 6.) * matrix)
-                .cholesky()
-                .expect("Hold up! Looks like my numeric knowledge isn't really numericing ;-----;")
-        };
-
-        let gradients = vec![0f32; amount_sections - 1].into_boxed_slice();
-        let gradient_diffs = vec![0f32; amount_sections - 1].into_boxed_slice();
+        let matrix = get_matrix(&section_widths);
+        let gradients = vec![0f32; amount_sections].into_boxed_slice();
+        let gradient_diffs = vec![0f32; amount_sections].into_boxed_slice();
 
         Self {
+            values,
+            ctx,
             section_widths,
             matrix,
             gradients,
             gradient_diffs,
-            gammas: DVector::zeros(amount_sections),
         }
     }
 }
 
 impl Interpolater for CubicSplineInterpolation {
-    fn interpolate(&mut self, ctx: &InterpolationCtx, buffer: &mut [f32]) {
-        assert!(!buffer.is_empty());
-        let supporting_points = ctx.supporting_points();
+    fn interpolate(&mut self) -> &[f32] {
+        for point in self.ctx.supporting_points.iter() {
+            self.values[point.x] = point.y;
+        }
 
         // == preparation ==
         // update gradients
-        for (i, next) in supporting_points[1..].iter().enumerate() {
-            let prev = &supporting_points[i];
+        for (i, next) in self.ctx.supporting_points[1..].iter().enumerate() {
+            let prev = &self.ctx.supporting_points[i];
             self.gradients[i] = (prev.y - next.y) / (prev.x as f32 - next.x as f32);
         }
 
         // update gradient diffs
-        for (i, &next) in self.gradients[1..].iter().enumerate() {
-            let prev = self.gradients[i];
-            self.gradient_diffs[i] = next - prev;
+        {
+            self.gradient_diffs[0] = self.gradients[0];
+
+            for (prev_idx, &next) in self.gradients[1..(self.gradients.len() - 1)]
+                .iter()
+                .enumerate()
+            {
+                let prev = self.gradients[prev_idx];
+                self.gradient_diffs[prev_idx + 1] = next - prev;
+            }
+
+            *self.gradient_diffs.last_mut().unwrap() = -self.gradients.last().unwrap();
         }
 
         // solve gamma
@@ -135,11 +84,11 @@ impl Interpolater for CubicSplineInterpolation {
             .solve(&DVector::from_column_slice(&self.gradient_diffs));
 
         // == interpolation ==
-        for section in ctx.sections() {
-            let n = supporting_points[section.start_supporting_point + 1].x;
+        for section in self.ctx.sections.iter() {
+            let n = section.left_supporting_point_idx + 1;
 
-            let left = &supporting_points[n - 1];
-            let right = &supporting_points[n];
+            let left = &self.ctx.supporting_points[n - 1];
+            let right = &self.ctx.supporting_points[n];
 
             let prev_gamma = gammas[n - 1];
             let next_gamma = gammas[n];
@@ -147,9 +96,10 @@ impl Interpolater for CubicSplineInterpolation {
             let gradient = self.gradients[n - 1];
             let section_width = self.section_widths[n - 1];
 
-            let amount = buffer.len();
-            for idx in 0..amount {
-                let x = (idx + 1 + left.x) as f32;
+            let amount = section.amount;
+            for interpolated_idx in 0..amount {
+                let bar_idx = interpolated_idx + 1 + left.x;
+                let x = bar_idx as f32;
 
                 let interpolated_value = left.y
                     + (x - left.x as f32) * gradient
@@ -157,10 +107,58 @@ impl Interpolater for CubicSplineInterpolation {
                         * ((prev_gamma + 2. * next_gamma) * (x - left.x as f32)
                             - (2. * prev_gamma + next_gamma) * (x - right.x as f32));
 
-                buffer[idx] = interpolated_value;
+                self.values[bar_idx] = interpolated_value;
             }
         }
+
+        &self.values
     }
+
+    fn total_amount_entries(&self) -> usize {
+        self.ctx.total_amount_entries()
+    }
+
+    fn supporting_points_mut(&mut self) -> std::slice::IterMut<'_, super::SupportingPoint> {
+        self.ctx.supporting_points.iter_mut()
+    }
+}
+
+fn get_matrix(section_widths: &[usize]) -> Cholesky<f32, Dyn> {
+    let amount_widths = section_widths.len();
+    let mut matrix = DMatrix::zeros(amount_widths, amount_widths);
+
+    // add first row
+    {
+        let mut first_row = matrix.row_mut(0);
+        first_row[0] = 2. * section_widths[0] as f32;
+        first_row[1] = section_widths[0] as f32;
+    }
+
+    // add rows in between
+    {
+        let mut offset = 0;
+        for row_idx in 1..(amount_widths - 1) {
+            let mut row = matrix.row_mut(row_idx);
+
+            row[offset] = section_widths[offset] as f32;
+            row[offset + 1] = 2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
+            row[offset + 2] = section_widths[offset + 1] as f32;
+
+            offset += 1;
+        }
+    }
+
+    // add last row
+    {
+        let mut last_row = matrix.row_mut(amount_widths - 1);
+
+        last_row[amount_widths - 2] = section_widths[amount_widths - 1] as f32;
+        last_row[amount_widths - 1] = 2. * section_widths[amount_widths - 1] as f32;
+    }
+
+    ((1. / 6.) * matrix.clone())
+        .cholesky()
+        .expect(&format!("Hold up! Looks like my numeric knowledge isn't really numericing ;-----;\nThe matrix which got calculated is: {}", matrix))
 }
 
 #[cfg(test)]
@@ -174,17 +172,20 @@ mod tests {
         const AMOUNT_POINTS: usize = 10;
         const AMOUNT_SECTIONS: usize = AMOUNT_POINTS - 1;
 
-        let ctx = {
-            let mut ctx = InterpolationCtx::new();
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 1, y: 0.0 },
+            SupportingPoint { x: 2, y: 0.0 },
+            SupportingPoint { x: 3, y: 0.0 },
+            SupportingPoint { x: 4, y: 0.0 },
+            SupportingPoint { x: 5, y: 0.0 },
+            SupportingPoint { x: 6, y: 0.0 },
+            SupportingPoint { x: 7, y: 0.0 },
+            SupportingPoint { x: 8, y: 0.0 },
+            SupportingPoint { x: 9, y: 0.0 },
+        ];
 
-            for x in 0..AMOUNT_POINTS {
-                ctx.add_supporting_point(SupportingPoint { x, y: 0.0 });
-            }
-
-            ctx
-        };
-
-        let interpolator = CubicSplineInterpolation::new(&ctx);
+        let interpolator = CubicSplineInterpolation::new(supporting_points);
 
         assert_eq!(interpolator.section_widths.as_ref(), &[1; AMOUNT_SECTIONS]);
 

--- a/shady-audio/src/interpolation/cubic_spline.rs
+++ b/shady-audio/src/interpolation/cubic_spline.rs
@@ -1,0 +1,217 @@
+use std::fmt::Write;
+
+use nalgebra::{Cholesky, DMatrix, DVector, Dyn};
+use tracing::debug;
+
+use super::{Interpolater, InterpolationCtx};
+
+type Width = usize;
+
+#[derive(Debug, Clone)]
+pub struct CubicSplineInterpolation {
+    section_widths: Box<[Width]>,
+
+    matrix: Cholesky<f32, Dyn>,
+    gradients: Box<[f32]>,
+    gradient_diffs: Box<[f32]>,
+
+    gammas: DVector<f32>,
+}
+
+impl CubicSplineInterpolation {
+    pub fn boxed(ctx: &InterpolationCtx) -> Box<Self> {
+        Box::new(Self::new(ctx))
+    }
+
+    pub fn new(ctx: &InterpolationCtx) -> Self {
+        let supporting_points = ctx.supporting_points();
+
+        let section_widths = {
+            let mut section_width = Vec::with_capacity(supporting_points.len() - 1);
+
+            let mut prev_width = supporting_points[0].x;
+            for anchor in supporting_points[1..].iter() {
+                let width = anchor.x - prev_width;
+                prev_width = anchor.x;
+
+                assert!(width > 0);
+
+                section_width.push(width);
+            }
+
+            section_width.into_boxed_slice()
+        };
+        let amount_sections = section_widths.len();
+
+        let matrix = {
+            let mut matrix = DMatrix::zeros(amount_sections, amount_sections);
+
+            // add first row
+            {
+                let mut first_row = matrix.row_mut(0);
+                first_row[0] = 2. * section_widths[0] as f32;
+                first_row[1] = section_widths[0] as f32;
+            }
+
+            // add rows in between
+            {
+                let mut offset = 0;
+                for row_idx in 1..(amount_sections - 1) {
+                    let mut row = matrix.row_mut(row_idx);
+
+                    row[offset] = section_widths[offset] as f32;
+                    row[offset + 1] =
+                        2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
+                    row[offset + 2] = section_widths[offset + 1] as f32;
+
+                    offset += 1;
+                }
+            }
+
+            // add last row
+            {
+                let mut last_row = matrix.row_mut(amount_sections - 1);
+
+                last_row[amount_sections - 2] = section_widths[amount_sections - 1] as f32;
+                last_row[amount_sections - 1] = 2. * section_widths[amount_sections - 1] as f32;
+            }
+
+            // just for debugging purposes
+            {
+                let mut dbg_matrix_msg = String::new();
+                for row_idx in 0..amount_sections {
+                    let row = matrix.row(row_idx);
+                    write!(&mut dbg_matrix_msg, "[").unwrap();
+                    for &value in row.columns_range(..amount_sections - 1) {
+                        write!(&mut dbg_matrix_msg, "{value}, ").unwrap();
+                    }
+                    write!(&mut dbg_matrix_msg, "{}]\n", row[amount_sections - 1]).unwrap();
+                }
+                debug!("Matrix:\n{}", dbg_matrix_msg)
+            }
+
+            debug_assert_eq!(matrix.row(0).len(), amount_sections);
+            debug_assert_eq!(matrix.column(0).len(), amount_sections);
+
+            ((1. / 6.) * matrix)
+                .cholesky()
+                .expect("Hold up! Looks like my numeric knowledge isn't really numericing ;-----;")
+        };
+
+        let gradients = vec![0f32; amount_sections - 1].into_boxed_slice();
+        let gradient_diffs = vec![0f32; amount_sections - 1].into_boxed_slice();
+
+        Self {
+            section_widths,
+            matrix,
+            gradients,
+            gradient_diffs,
+            gammas: DVector::zeros(amount_sections),
+        }
+    }
+}
+
+impl Interpolater for CubicSplineInterpolation {
+    fn interpolate(&mut self, ctx: &InterpolationCtx, buffer: &mut [f32]) {
+        assert!(!buffer.is_empty());
+        let supporting_points = ctx.supporting_points();
+
+        // == preparation ==
+        // update gradients
+        for (i, next) in supporting_points[1..].iter().enumerate() {
+            let prev = &supporting_points[i];
+            self.gradients[i] = (prev.y - next.y) / (prev.x as f32 - next.x as f32);
+        }
+
+        // update gradient diffs
+        for (i, &next) in self.gradients[1..].iter().enumerate() {
+            let prev = self.gradients[i];
+            self.gradient_diffs[i] = next - prev;
+        }
+
+        // solve gamma
+        let gammas = self
+            .matrix
+            .solve(&DVector::from_column_slice(&self.gradient_diffs));
+
+        // == interpolation ==
+        for section in ctx.sections() {
+            let n = supporting_points[section.start_supporting_point + 1].x;
+
+            let left = &supporting_points[n - 1];
+            let right = &supporting_points[n];
+
+            let prev_gamma = gammas[n - 1];
+            let next_gamma = gammas[n];
+
+            let gradient = self.gradients[n - 1];
+            let section_width = self.section_widths[n - 1];
+
+            let amount = buffer.len();
+            for idx in 0..amount {
+                let x = (idx + 1 + left.x) as f32;
+
+                let interpolated_value = left.y
+                    + (x - left.x as f32) * gradient
+                    + ((x - left.x as f32) * (x - right.x as f32)) / (6. * section_width as f32)
+                        * ((prev_gamma + 2. * next_gamma) * (x - left.x as f32)
+                            - (2. * prev_gamma + next_gamma) * (x - right.x as f32));
+
+                buffer[idx] = interpolated_value;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interpolation::SupportingPoint;
+
+    use super::*;
+
+    #[test]
+    fn equidistant_supporting_points() {
+        const AMOUNT_POINTS: usize = 10;
+        const AMOUNT_SECTIONS: usize = AMOUNT_POINTS - 1;
+
+        let ctx = {
+            let mut ctx = InterpolationCtx::new();
+
+            for x in 0..AMOUNT_POINTS {
+                ctx.add_supporting_point(SupportingPoint { x, y: 0.0 });
+            }
+
+            ctx
+        };
+
+        let interpolator = CubicSplineInterpolation::new(&ctx);
+
+        assert_eq!(interpolator.section_widths.as_ref(), &[1; AMOUNT_SECTIONS]);
+
+        // check matrix
+        {
+            #[rustfmt::skip]
+            let expected_matrix = {
+                let mut matrix = DMatrix::from_row_slice(
+                AMOUNT_SECTIONS,
+                AMOUNT_SECTIONS,
+                &[
+                            2., 1., 0., 0., 0., 0., 0., 0., 0.,
+                            1., 4., 1., 0., 0., 0., 0., 0., 0.,
+                            0., 1., 4., 1., 0., 0., 0., 0., 0.,
+                            0., 0., 1., 4., 1., 0., 0., 0., 0.,
+                            0., 0., 0., 1., 4., 1., 0., 0., 0.,
+                            0., 0., 0., 0., 1., 4., 1., 0., 0.,
+                            0., 0., 0., 0., 0., 1., 4., 1., 0.,
+                            0., 0., 0., 0., 0., 0., 1., 4., 1.,
+                            0., 0., 0., 0., 0., 0., 0., 1., 2.,
+                        ]);
+
+                matrix *= 1. / 6.;
+                matrix.cholesky().unwrap()
+            };
+
+            assert_eq!(interpolator.matrix.l(), expected_matrix.l());
+        }
+    }
+}

--- a/shady-audio/src/interpolation/cubic_spline.rs
+++ b/shady-audio/src/interpolation/cubic_spline.rs
@@ -136,15 +136,12 @@ fn get_matrix(section_widths: &[usize]) -> Cholesky<f32, Dyn> {
 
     // add rows in between
     {
-        let mut offset = 0;
-        for row_idx in 1..(amount_widths - 1) {
+        for (offset, row_idx) in (1..(amount_widths - 1)).enumerate() {
             let mut row = matrix.row_mut(row_idx);
 
             row[offset] = section_widths[offset] as f32;
             row[offset + 1] = 2. * (section_widths[offset] + section_widths[offset + 1]) as f32;
             row[offset + 2] = section_widths[offset + 1] as f32;
-
-            offset += 1;
         }
     }
 
@@ -158,7 +155,7 @@ fn get_matrix(section_widths: &[usize]) -> Cholesky<f32, Dyn> {
 
     ((1. / 6.) * matrix.clone())
         .cholesky()
-        .expect(&format!("Hold up! Looks like my numeric knowledge isn't really numericing ;-----;\nThe matrix which got calculated is: {}", matrix))
+        .unwrap_or_else( || panic!("Hold up! Looks like my numeric knowledge isn't really numericing ;-----;\nThe matrix which got calculated is: {}", matrix))
 }
 
 #[cfg(test)]

--- a/shady-audio/src/interpolation/linear.rs
+++ b/shady-audio/src/interpolation/linear.rs
@@ -1,0 +1,117 @@
+use std::slice::IterMut;
+
+use tracing::debug;
+
+use super::{context::InterpolationCtx, Interpolater, InterpolationInstantiator, SupportingPoint};
+
+#[derive(Debug)]
+pub struct LinearInterpolation {
+    ctx: InterpolationCtx,
+
+    values: Box<[f32]>,
+}
+
+impl InterpolationInstantiator for LinearInterpolation {
+    fn new(supporting_points: impl IntoIterator<Item = super::SupportingPoint>) -> Self {
+        let ctx = InterpolationCtx::new(supporting_points);
+        let values = vec![0f32; ctx.total_amount_entries()].into_boxed_slice();
+
+        Self { ctx, values }
+    }
+}
+
+impl Interpolater for LinearInterpolation {
+    fn interpolate(&mut self) -> &[f32] {
+        for point in self.ctx.supporting_points.iter() {
+            self.values[point.x] = point.y;
+        }
+
+        debug!("{:?}", self.ctx);
+
+        for section in self.ctx.sections.iter() {
+            let left = &self.ctx.supporting_points[section.left_supporting_point_idx];
+            let right = &self.ctx.supporting_points[section.left_supporting_point_idx + 1];
+
+            let amount = section.amount;
+            for interpolate_idx in 0..amount {
+                let t = (interpolate_idx + 1) as f32 / (amount + 1) as f32;
+
+                let idx = left.x + interpolate_idx + 1;
+                self.values[idx] = t * right.y + (1. - t) * left.y;
+            }
+        }
+
+        &self.values
+    }
+
+    fn supporting_points_mut(&mut self) -> IterMut<'_, SupportingPoint> {
+        self.ctx.supporting_points.iter_mut()
+    }
+
+    fn total_amount_entries(&self) -> usize {
+        self.values.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_supporting_points_and_zero_sections() {
+        let mut interpolator = LinearInterpolation::new([]);
+        assert_eq!(interpolator.interpolate(), []);
+    }
+
+    #[test]
+    fn one_supporting_point_and_zero_sections() {
+        let supporting_points = [SupportingPoint { x: 0, y: 0.5 }];
+
+        let mut interpolator = LinearInterpolation::new(supporting_points);
+
+        assert_eq!(interpolator.interpolate(), &[0.5]);
+    }
+
+    #[test]
+    fn two_supporting_points_and_one_section() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 4, y: 1.0 },
+        ];
+
+        let mut interpolator = LinearInterpolation::new(supporting_points);
+
+        assert_eq!(interpolator.interpolate(), &[0.0, 0.25, 0.5, 0.75, 1.0]);
+    }
+
+    #[test]
+    fn three_supporting_points_and_one_section() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 2, y: 1.0 },
+            SupportingPoint { x: 3, y: 0.0 },
+        ];
+
+        let mut interpolator = LinearInterpolation::new(supporting_points);
+
+        assert_eq!(interpolator.interpolate(), &[0.0, 0.5, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn three_supporting_points_and_two_sections() {
+        let supporting_points = [
+            SupportingPoint { x: 0, y: 0.0 },
+            SupportingPoint { x: 2, y: 1.0 },
+            SupportingPoint { x: 6, y: 0.0 },
+        ];
+
+        let mut interpolator = LinearInterpolation::new(supporting_points);
+
+        println!("{:?}", interpolator.ctx);
+
+        assert_eq!(
+            interpolator.interpolate(),
+            &[0.0, 0.5, 1.0, 0.75, 0.5, 0.25, 0.0],
+        );
+    }
+}

--- a/shady-audio/src/interpolation/mod.rs
+++ b/shady-audio/src/interpolation/mod.rs
@@ -1,0 +1,47 @@
+mod context;
+mod nothing;
+// mod cubic_spline;
+mod linear;
+
+use std::slice::IterMut;
+
+// pub use cubic_spline::CubicSplineInterpolation;
+pub use linear::LinearInterpolation;
+pub use nothing::NothingInterpolation;
+
+pub trait Interpolater {
+    fn interpolate(&mut self) -> &[f32];
+
+    /// The length of the returned slice of `interpolate()`.
+    fn total_amount_entries(&self) -> usize;
+
+    fn supporting_points_mut(&mut self) -> IterMut<'_, SupportingPoint>;
+}
+
+pub trait InterpolationInstantiator: Interpolater + Sized {
+    fn new(supporting_points: impl IntoIterator<Item = SupportingPoint>) -> Self;
+
+    fn boxed(supporting_points: impl IntoIterator<Item = SupportingPoint>) -> Box<Self> {
+        Box::new(Self::new(supporting_points))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SupportingPoint {
+    /// The x value of the supporting point
+    pub x: usize,
+
+    /// The y value of the supporting point
+    pub y: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InterpolationSection {
+    // assuming the supporting points are stored in an indexable data structure.
+    // The attribute stores the index of the supporting point within the data sturcture.
+    pub left_supporting_point_idx: usize,
+
+    /// the amount of points which need to be interpolated
+    /// within this section (up to the next supporting point)
+    pub amount: usize,
+}

--- a/shady-audio/src/interpolation/mod.rs
+++ b/shady-audio/src/interpolation/mod.rs
@@ -9,6 +9,21 @@ pub use cubic_spline::CubicSplineInterpolation;
 pub use linear::LinearInterpolation;
 pub use nothing::NothingInterpolation;
 
+/// Decides which interpolation strategy should be used.
+#[derive(Debug, Clone, Copy, Hash)]
+pub enum InterpolationVariant {
+    /// No interpolation strategy should be used.
+    ///
+    /// Only the supporting bars which are calculated are going to be displayed.
+    None,
+
+    /// Use the linear interpolation.
+    Linear,
+
+    /// Use the cubic spline interpolation.
+    CubicSpline,
+}
+
 pub trait Interpolater {
     fn interpolate(&mut self) -> &[f32];
 

--- a/shady-audio/src/interpolation/mod.rs
+++ b/shady-audio/src/interpolation/mod.rs
@@ -1,11 +1,11 @@
 mod context;
-mod nothing;
-// mod cubic_spline;
+mod cubic_spline;
 mod linear;
+mod nothing;
 
 use std::slice::IterMut;
 
-// pub use cubic_spline::CubicSplineInterpolation;
+pub use cubic_spline::CubicSplineInterpolation;
 pub use linear::LinearInterpolation;
 pub use nothing::NothingInterpolation;
 

--- a/shady-audio/src/interpolation/nothing.rs
+++ b/shady-audio/src/interpolation/nothing.rs
@@ -1,0 +1,35 @@
+use super::{context::InterpolationCtx, Interpolater, InterpolationInstantiator};
+
+#[derive(Debug)]
+pub struct NothingInterpolation {
+    ctx: InterpolationCtx,
+    values: Box<[f32]>,
+}
+
+impl InterpolationInstantiator for NothingInterpolation {
+    fn new(supporting_points: impl IntoIterator<Item = super::SupportingPoint>) -> Self {
+        let ctx = InterpolationCtx::new(supporting_points);
+
+        let values = vec![0f32; ctx.total_amount_entries()].into_boxed_slice();
+
+        Self { ctx, values }
+    }
+}
+
+impl Interpolater for NothingInterpolation {
+    fn interpolate(&mut self) -> &[f32] {
+        for point in self.ctx.supporting_points.iter() {
+            self.values[point.x] = point.y;
+        }
+
+        &self.values
+    }
+
+    fn total_amount_entries(&self) -> usize {
+        self.ctx.total_amount_entries()
+    }
+
+    fn supporting_points_mut(&mut self) -> std::slice::IterMut<'_, super::SupportingPoint> {
+        self.ctx.supporting_points.iter_mut()
+    }
+}

--- a/shady-audio/src/lib.rs
+++ b/shady-audio/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 pub mod config;
 pub mod fetcher;
+pub mod interpolation;
 
 mod equalizer;
 mod error;


### PR DESCRIPTION
Closes https://github.com/TornaxO7/shady/issues/51

Adds the following interpolation variants:
- `None`: No interpolation is going to be applied
- `Linear`: Linear interpolation is going to be applied
- `Cubic Spline`: Cubic spline interpolation is going to be applied

This also improves the performance which makes it efficient similar to cava.